### PR TITLE
Fix WinSize struct W/H

### DIFF
--- a/console.go
+++ b/console.go
@@ -30,12 +30,12 @@ type Console interface {
 
 // WinSize specifies the window size of the console
 type WinSize struct {
-	// Width of the console
-	Width uint16
 	// Height of the console
 	Height uint16
-	x      uint16
-	y      uint16
+	// Width of the console
+	Width uint16
+	x     uint16
+	y     uint16
 }
 
 // Current returns the current processes console

--- a/console_test.go
+++ b/console_test.go
@@ -1,0 +1,31 @@
+// +build linux
+
+package console
+
+import "testing"
+
+func TestWinSize(t *testing.T) {
+	c, _, err := NewPty()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if err := c.Resize(WinSize{
+		Width:  11,
+		Height: 10,
+	}); err != nil {
+		t.Error(err)
+		return
+	}
+	size, err := c.Size()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if size.Width != 11 {
+		t.Errorf("width should be 11 but received %d", size.Width)
+	}
+	if size.Height != 10 {
+		t.Errorf("height should be 10 but received %d", size.Height)
+	}
+}


### PR DESCRIPTION
This needs to be reordered with Height first then Width to match struct
winsize.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>