### PR TITLE
Remove use of cgo

### DIFF
--- a/console_unix.go
+++ b/console_unix.go
@@ -2,9 +2,6 @@
 
 package console
 
-// #include <termios.h>
-import "C"
-
 import (
 	"os"
 	"unsafe"
@@ -91,8 +88,8 @@ func (m *master) SetRaw() error {
 	if err != nil {
 		return err
 	}
-	C.cfmakeraw((*C.struct_termios)(unsafe.Pointer(&rawState)))
-	rawState.Oflag = rawState.Oflag | C.OPOST
+	rawState = cfmakeraw(rawState)
+	rawState.Oflag = rawState.Oflag | unix.OPOST
 	return tcset(m.f.Fd(), &rawState)
 }
 

--- a/tc_darwin.go
+++ b/tc_darwin.go
@@ -49,3 +49,15 @@ func saneTerminal(f *os.File) error {
 	termios.Oflag &^= unix.ONLCR
 	return tcset(f.Fd(), &termios)
 }
+
+func cfmakeraw(t unix.Termios) unix.Termios {
+	t.Iflag = uint64(uint32(t.Iflag) & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)))
+	t.Oflag = uint64(uint32(t.Oflag) & ^uint32(unix.OPOST))
+	t.Lflag = uint64(uint32(t.Lflag) & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)))
+	t.Cflag = uint64(uint32(t.Cflag) & ^(uint32(unix.CSIZE | unix.PARENB)))
+	t.Cflag = t.Cflag | unix.CS8
+	t.Cc[unix.VMIN] = 1
+	t.Cc[unix.VTIME] = 0
+
+	return t
+}

--- a/tc_freebsd.go
+++ b/tc_freebsd.go
@@ -49,3 +49,15 @@ func saneTerminal(f *os.File) error {
 	termios.Oflag &^= unix.ONLCR
 	return tcset(f.Fd(), &termios)
 }
+
+func cfmakeraw(t unix.Termios) unix.Termios {
+	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
+	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
+	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
+	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
+	t.Cflag = t.Cflag | unix.CS8
+	t.Cc[unix.VMIN] = 1
+	t.Cc[unix.VTIME] = 0
+
+	return t
+}

--- a/tc_linux.go
+++ b/tc_linux.go
@@ -49,3 +49,15 @@ func saneTerminal(f *os.File) error {
 	termios.Oflag &^= unix.ONLCR
 	return tcset(f.Fd(), &termios)
 }
+
+func cfmakeraw(t unix.Termios) unix.Termios {
+	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
+	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
+	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
+	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
+	t.Cflag = t.Cflag | unix.CS8
+	t.Cc[unix.VMIN] = 1
+	t.Cc[unix.VTIME] = 0
+
+	return t
+}


### PR DESCRIPTION
Define `tcmakeraw` directly in Go instead of using C. Allows for easier
cross compile.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

With this you can mostly cross compile `containerd` for Darwin on Linux (one more fix needed) as the cgo code removed. See https://github.com/containerd/containerd/issues/866