### PR TITLE
Fix go vet warning

### DIFF
--- a/console_linux.go
+++ b/console_linux.go
@@ -1,4 +1,5 @@
 // +build linux
+
 package console
 
 import (


### PR DESCRIPTION
Fix the following warning issued by 'go vet' by adding a blank line
after the build clause:

  console_linux.go:1: +build comment must appear before package clause and be followed by a blank line

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>