### PR TITLE
Add solaris build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ go_import_path: github.com/containerd/console
 install:
   - go get -d
   - GOOS=windows go get -d
+  - GOOS=solaris go get -d
 
 script:
   - go test -race
   - GOOS=windows go test
+  - GOOS=solaris go build
+  - GOOS=solaris go test -c

--- a/console_unix.go
+++ b/console_unix.go
@@ -1,10 +1,9 @@
-// +build darwin freebsd linux
+// +build darwin freebsd linux solaris
 
 package console
 
 import (
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -50,11 +49,7 @@ func (m *master) Close() error {
 }
 
 func (m *master) Resize(ws WinSize) error {
-	return ioctl(
-		m.f.Fd(),
-		uintptr(unix.TIOCSWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	)
+	return tcswinsz(m.f.Fd(), ws)
 }
 
 func (m *master) ResizeFrom(c Console) error {
@@ -103,15 +98,7 @@ func (m *master) DisableEcho() error {
 }
 
 func (m *master) Size() (WinSize, error) {
-	var ws WinSize
-	if err := ioctl(
-		m.f.Fd(),
-		uintptr(unix.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	); err != nil {
-		return ws, err
-	}
-	return ws, nil
+	return tcgwinsz(m.f.Fd())
 }
 
 func (m *master) Fd() uintptr {

--- a/tc_darwin.go
+++ b/tc_darwin.go
@@ -16,6 +16,26 @@ func tcset(fd uintptr, p *unix.Termios) error {
 	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
 }
 
+func tcgwinsz(fd uintptr) (WinSize, error) {
+	var ws WinSize
+	if err := ioctl(
+		fd,
+		uintptr(unix.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	); err != nil {
+		return ws, err
+	}
+	return ws, nil
+}
+
+func tcswinsz(fd uintptr, ws WinSize) error {
+	return ioctl(
+		fd,
+		uintptr(unix.TIOCSWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	)
+}
+
 func ioctl(fd, flag, data uintptr) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
 		return err

--- a/tc_freebsd.go
+++ b/tc_freebsd.go
@@ -16,6 +16,26 @@ func tcset(fd uintptr, p *unix.Termios) error {
 	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
 }
 
+func tcgwinsz(fd uintptr) (WinSize, error) {
+	var ws WinSize
+	if err := ioctl(
+		fd,
+		uintptr(unix.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	); err != nil {
+		return ws, err
+	}
+	return ws, nil
+}
+
+func tcswinsz(fd uintptr, ws WinSize) error {
+	return ioctl(
+		fd,
+		uintptr(unix.TIOCSWINSZ),
+		uintptr(unsafe.Pointer(&ws)),
+	)
+}
+
 func ioctl(fd, flag, data uintptr) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
 		return err

--- a/tc_linux.go
+++ b/tc_linux.go
@@ -8,19 +8,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func tcget(fd uintptr, p *unix.Termios) error {
-	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
-	if err != nil {
-		return err
-	}
-	*p = *termios
-	return nil
-}
-
-func tcset(fd uintptr, p *unix.Termios) error {
-	return unix.IoctlSetTermios(int(fd), unix.TCSETS, p)
-}
-
 func ioctl(fd, flag, data uintptr) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
 		return err
@@ -42,26 +29,4 @@ func ptsname(f *os.File) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("/dev/pts/%d", n), nil
-}
-
-func saneTerminal(f *os.File) error {
-	var termios unix.Termios
-	if err := tcget(f.Fd(), &termios); err != nil {
-		return err
-	}
-	// Set -onlcr so we don't have to deal with \r.
-	termios.Oflag &^= unix.ONLCR
-	return tcset(f.Fd(), &termios)
-}
-
-func cfmakeraw(t unix.Termios) unix.Termios {
-	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
-	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
-	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
-	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
-	t.Cflag = t.Cflag | unix.CS8
-	t.Cc[unix.VMIN] = 1
-	t.Cc[unix.VTIME] = 0
-
-	return t
 }

--- a/tc_solaris_cgo.go
+++ b/tc_solaris_cgo.go
@@ -1,0 +1,28 @@
+// +build solaris,cgo
+
+package console
+
+import (
+	"os"
+)
+
+//#include <stdlib.h>
+import "C"
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	ptspath, err := C.ptsname(C.int(f.Fd()))
+	if err != nil {
+		return "", err
+	}
+	return C.GoString(ptspath), nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	if _, err := C.grantpt(C.int(f.Fd())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tc_solaris_nocgo.go
+++ b/tc_solaris_nocgo.go
@@ -1,0 +1,24 @@
+// +build solaris,!cgo
+
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
+package console
+
+import (
+	"os"
+)
+
+func ptsname(f *os.File) (string, error) {
+	panic("ptsname() support requires cgo.")
+}
+
+func unlockpt(f *os.File) error {
+	panic("unlockpt() support requires cgo.")
+}

--- a/tc_unix.go
+++ b/tc_unix.go
@@ -1,0 +1,72 @@
+// +build linux solaris
+
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tcget(fd uintptr, p *unix.Termios) error {
+	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	if err != nil {
+		return err
+	}
+	*p = *termios
+	return nil
+}
+
+func tcset(fd uintptr, p *unix.Termios) error {
+	return unix.IoctlSetTermios(int(fd), unix.TCSETS, p)
+}
+
+func tcgwinsz(fd uintptr) (WinSize, error) {
+	var ws WinSize
+
+	uws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+	if err != nil {
+		return ws, err
+	}
+
+	// Translate from unix.Winsize to console.WinSize
+	ws.Height = uws.Row
+	ws.Width = uws.Col
+	ws.x = uws.Xpixel
+	ws.y = uws.Ypixel
+	return ws, nil
+}
+
+func tcswinsz(fd uintptr, ws WinSize) error {
+	// Translate from console.WinSize to unix.Winsize
+
+	var uws unix.Winsize
+	uws.Row = ws.Height
+	uws.Col = ws.Width
+	uws.Xpixel = ws.x
+	uws.Ypixel = ws.y
+
+	return unix.IoctlSetWinsize(int(fd), unix.TIOCSWINSZ, &uws)
+}
+
+func saneTerminal(f *os.File) error {
+	var termios unix.Termios
+	if err := tcget(f.Fd(), &termios); err != nil {
+		return err
+	}
+	// Set -onlcr so we don't have to deal with \r.
+	termios.Oflag &^= unix.ONLCR
+	return tcset(f.Fd(), &termios)
+}
+
+func cfmakeraw(t unix.Termios) unix.Termios {
+	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
+	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
+	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
+	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
+	t.Cflag = t.Cflag | unix.CS8
+	t.Cc[unix.VMIN] = 1
+	t.Cc[unix.VTIME] = 0
+
+	return t
+}


### PR DESCRIPTION
since the last moby summit i've been working on porting containerd to
solaris.  to do this i need to make changes to this vendored component.

at the summit i was asked to try and err on the side of having multiple
smaller changesets rather than one large changeset.  to that end, this
pull request contains the smallest amount of changes necessary to get
this component to compile on solaris, to cross-compile for solaris on
linux, and to test solaris cross-compilation on linux via travis ci.

it's worth mentioning that while these these changes allow solaris
cross-compilation on linux, the resultant binary isn't actually usable
on solaris.  this is because compilation of this component on solaris
requires the use of cgo, and we can't cross-compile solaris cgo code on
linux.  I chose to enable cross-compilation (even though the resultant
binary is broken) because that allows us to do testing via travis ci,
similar to what is currently being done for windows.

unfortunately, while these changes allow this components and it's tests
to build and run solaris, some of the included tests fail.  i plan to
fix the tests as follow on work.  i didn't want to include that here
because i wanted to keep this changeset as small and self contained as
possible.