### PR TITLE
Use common tc* functions on FreeBSD and Darwin

### DIFF
--- a/tc_darwin.go
+++ b/tc_darwin.go
@@ -8,33 +8,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func tcget(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
-}
-
-func tcset(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
-}
-
-func tcgwinsz(fd uintptr) (WinSize, error) {
-	var ws WinSize
-	if err := ioctl(
-		fd,
-		uintptr(unix.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	); err != nil {
-		return ws, err
-	}
-	return ws, nil
-}
-
-func tcswinsz(fd uintptr, ws WinSize) error {
-	return ioctl(
-		fd,
-		uintptr(unix.TIOCSWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	)
-}
+const (
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
+)
 
 func ioctl(fd, flag, data uintptr) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
@@ -52,32 +29,9 @@ func unlockpt(f *os.File) error {
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	var n int32
-	if err := ioctl(f.Fd(), unix.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n))); err != nil {
+	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCPTYGNAME)
+	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("/dev/pts/%d", n), nil
-}
-
-func saneTerminal(f *os.File) error {
-	// Go doesn't have a wrapper for any of the termios ioctls.
-	var termios unix.Termios
-	if err := tcget(f.Fd(), &termios); err != nil {
-		return err
-	}
-	// Set -onlcr so we don't have to deal with \r.
-	termios.Oflag &^= unix.ONLCR
-	return tcset(f.Fd(), &termios)
-}
-
-func cfmakeraw(t unix.Termios) unix.Termios {
-	t.Iflag = uint64(uint32(t.Iflag) & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)))
-	t.Oflag = uint64(uint32(t.Oflag) & ^uint32(unix.OPOST))
-	t.Lflag = uint64(uint32(t.Lflag) & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)))
-	t.Cflag = uint64(uint32(t.Cflag) & ^(uint32(unix.CSIZE | unix.PARENB)))
-	t.Cflag = t.Cflag | unix.CS8
-	t.Cc[unix.VMIN] = 1
-	t.Cc[unix.VTIME] = 0
-
-	return t
 }

--- a/tc_freebsd.go
+++ b/tc_freebsd.go
@@ -3,45 +3,14 @@ package console
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
-func tcget(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
-}
-
-func tcset(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
-}
-
-func tcgwinsz(fd uintptr) (WinSize, error) {
-	var ws WinSize
-	if err := ioctl(
-		fd,
-		uintptr(unix.TIOCGWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	); err != nil {
-		return ws, err
-	}
-	return ws, nil
-}
-
-func tcswinsz(fd uintptr, ws WinSize) error {
-	return ioctl(
-		fd,
-		uintptr(unix.TIOCSWINSZ),
-		uintptr(unsafe.Pointer(&ws)),
-	)
-}
-
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
-		return err
-	}
-	return nil
-}
+const (
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
+)
 
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
@@ -52,32 +21,9 @@ func unlockpt(f *os.File) error {
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	var n int32
-	if err := ioctl(f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
+	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
+	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("/dev/pts/%d", n), nil
-}
-
-func saneTerminal(f *os.File) error {
-	// Go doesn't have a wrapper for any of the termios ioctls.
-	var termios unix.Termios
-	if err := tcget(f.Fd(), &termios); err != nil {
-		return err
-	}
-	// Set -onlcr so we don't have to deal with \r.
-	termios.Oflag &^= unix.ONLCR
-	return tcset(f.Fd(), &termios)
-}
-
-func cfmakeraw(t unix.Termios) unix.Termios {
-	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
-	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
-	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
-	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
-	t.Cflag = t.Cflag | unix.CS8
-	t.Cc[unix.VMIN] = 1
-	t.Cc[unix.VTIME] = 0
-
-	return t
 }

--- a/tc_linux.go
+++ b/tc_linux.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	cmdTcGet = unix.TCGETS
+	cmdTcSet = unix.TCSETS
+)
+
 func ioctl(fd, flag, data uintptr) error {
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
 		return err

--- a/tc_solaris_cgo.go
+++ b/tc_solaris_cgo.go
@@ -4,10 +4,17 @@ package console
 
 import (
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 //#include <stdlib.h>
 import "C"
+
+const (
+	cmdTcGet = unix.TCGETS
+	cmdTcSet = unix.TCSETS
+)
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {

--- a/tc_solaris_nocgo.go
+++ b/tc_solaris_nocgo.go
@@ -13,6 +13,13 @@ package console
 
 import (
 	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	cmdTcGet = unix.TCGETS
+	cmdTcSet = unix.TCSETS
 )
 
 func ptsname(f *os.File) (string, error) {

--- a/tc_unix.go
+++ b/tc_unix.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build darwin freebsd linux solaris
 
 package console
 
@@ -9,7 +9,7 @@ import (
 )
 
 func tcget(fd uintptr, p *unix.Termios) error {
-	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	termios, err := unix.IoctlGetTermios(int(fd), cmdTcGet)
 	if err != nil {
 		return err
 	}
@@ -18,7 +18,7 @@ func tcget(fd uintptr, p *unix.Termios) error {
 }
 
 func tcset(fd uintptr, p *unix.Termios) error {
-	return unix.IoctlSetTermios(int(fd), unix.TCSETS, p)
+	return unix.IoctlSetTermios(int(fd), cmdTcSet, p)
 }
 
 func tcgwinsz(fd uintptr) (WinSize, error) {
@@ -60,11 +60,11 @@ func saneTerminal(f *os.File) error {
 }
 
 func cfmakeraw(t unix.Termios) unix.Termios {
-	t.Iflag = t.Iflag & ^uint32((unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON))
-	t.Oflag = t.Oflag & ^uint32(unix.OPOST)
-	t.Lflag = t.Lflag & ^(uint32(unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN))
-	t.Cflag = t.Cflag & ^(uint32(unix.CSIZE | unix.PARENB))
-	t.Cflag = t.Cflag | unix.CS8
+	t.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
+	t.Oflag &^= unix.OPOST
+	t.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	t.Cflag &^= (unix.CSIZE | unix.PARENB)
+	t.Cflag &^= unix.CS8
 	t.Cc[unix.VMIN] = 1
 	t.Cc[unix.VTIME] = 0
 


### PR DESCRIPTION
The functions IoctlGetTermios/IoctlSetTermios and
IoctlGetWinsize/IoctlSetWinsize were recently added to package
golang.org/x/sys/unix for Darwin and FreeBSD. This allows to reduce code
duplication and combine the implementations for tcget, tcset, tcgwinsz,
tcswinsz, saneTerminal and cfmakeraw for Darwin, FreeBSD, Linux and
Solaris.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>