### PR TITLE
Fix ptsname() for big-endian architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.9.x
+  - 1.9.3
+  - 1.9.4
   - tip
 
 go_import_path: github.com/containerd/console
@@ -15,3 +16,8 @@ script:
   - GOOS=windows go test
   - GOOS=solaris go build
   - GOOS=solaris go test -c
+
+matrix:
+  allow_failures:
+    - go: 1.9.4
+

--- a/tc_linux.go
+++ b/tc_linux.go
@@ -13,25 +13,21 @@ const (
 	cmdTcSet = unix.TCSETS
 )
 
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return err
 	}
 	return nil
 }
 
-// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
-// unlockpt should be called before opening the slave side of a pty.
-func unlockpt(f *os.File) error {
-	var u int32
-	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
-}
-
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
-	if err != nil {
+	var u uint32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}
-	return fmt.Sprintf("/dev/pts/%d", n), nil
+	return fmt.Sprintf("/dev/pts/%d", u), nil
 }


### PR DESCRIPTION
On big-endian architectures unix.IoctlGetInt() leads to a wrong result
because a 32 bit value is stored into a 64 bit buffer. When dereferencing
the result is left shifted by 32. Without this patch ptsname() returns
a wrong path from the second pty onwards.
To protect syscalls against re-arranging by the GC the conversion from
unsafe.Pointer to uintptr must occur in the Syscall expression itself.
See the documentation of the unsafe package for details.

Signed-off-by: Peter Morjan <peter.morjan@de.ibm.com>