### PR TITLE
Add OpenBSD support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,17 @@ go_import_path: github.com/containerd/console
 
 install:
   - go get -d
-  - GOOS=windows go get -d
+  - GOOS=openbsd go get -d
   - GOOS=solaris go get -d
+  - GOOS=windows go get -d
 
 script:
   - go test -race
-  - GOOS=windows go test
+  - GOOS=openbsd go build
+  - GOOS=openbsd go test -c
   - GOOS=solaris go build
   - GOOS=solaris go test -c
+  - GOOS=windows go test
 
 matrix:
   allow_failures:

--- a/console_unix.go
+++ b/console_unix.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd linux solaris
+// +build darwin freebsd linux openbsd solaris
 
 package console
 

--- a/tc_openbsd_cgo.go
+++ b/tc_openbsd_cgo.go
@@ -1,0 +1,35 @@
+// +build openbsd,cgo
+
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+//#include <stdlib.h>
+import "C"
+
+const (
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
+)
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	ptspath, err := C.ptsname(C.int(f.Fd()))
+	if err != nil {
+		return "", err
+	}
+	return C.GoString(ptspath), nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	if _, err := C.grantpt(C.int(f.Fd())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tc_openbsd_nocgo.go
+++ b/tc_openbsd_nocgo.go
@@ -1,0 +1,31 @@
+// +build openbsd,!cgo
+
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
+)
+
+func ptsname(f *os.File) (string, error) {
+	panic("ptsname() support requires cgo.")
+}
+
+func unlockpt(f *os.File) error {
+	panic("unlockpt() support requires cgo.")
+}

--- a/tc_unix.go
+++ b/tc_unix.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd linux solaris
+// +build darwin freebsd linux openbsd solaris
 
 package console
 


### PR DESCRIPTION
As neither `TIOCGPTN` nor `TIOCPTYGNAME` syscalls are supported on OpenBSD there is the same story as it is with Solaris - we have to use libc funcions.