### PR TITLE
Update to Go 1.10; remove 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.9.3
   - 1.9.4
+  - 1.10.x
   - tip
 
 go_import_path: github.com/containerd/console


### PR DESCRIPTION
Attempt to keep other containerd projects in line with containerd itself re: Go versions.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>