### PR TITLE
console_linux: Fix race: lock Cond before Signal.

### DIFF
--- a/console_linux.go
+++ b/console_linux.go
@@ -262,10 +262,14 @@ func (ec *EpollConsole) Shutdown(close func(int) error) error {
 
 // signalRead signals that the console is readable.
 func (ec *EpollConsole) signalRead() {
+	ec.readc.L.Lock()
 	ec.readc.Signal()
+	ec.readc.L.Unlock()
 }
 
 // signalWrite signals that the console is writable.
 func (ec *EpollConsole) signalWrite() {
+	ec.writec.L.Lock()
 	ec.writec.Signal()
+	ec.writec.L.Unlock()
 }


### PR DESCRIPTION
Possible race:
```

Thread1:			Thread2:
line 178: Read() -> EAGAIN	...
<reschedule>			line 110: EpollWait()
...				line 124: signalRead()
...				...
line 191: Wait()		...
				line 110: EpollWait()

```
Thread2 (epoll) sends signalRead() (via sync.Cond) but Thread1 is not waiting
yet. Then is start to wait, but no more signals will arrive (because Thread2
is sleeping in EpollWait() on edge-triggered epoll.

To prevent this race one should held Lock when sending signalRead().

The same situation goes with Write loop.

Bug was reported to docker: https://github.com/docker/for-linux/issues/353

Signed-off-by: Alexander Gerasiov <gerasiov@yandex-team.ru>