### PR TITLE
Add File interface instead of using os.File

### DIFF
--- a/console.go
+++ b/console.go
@@ -24,10 +24,17 @@ import (
 
 var ErrNotAConsole = errors.New("provided file is not a console")
 
+type File interface {
+	io.ReadWriteCloser
+
+	// Fd returns its file descriptor
+	Fd() uintptr
+	// Name returns its file name
+	Name() string
+}
+
 type Console interface {
-	io.Reader
-	io.Writer
-	io.Closer
+	File
 
 	// Resize resizes the console to the provided window size
 	Resize(WinSize) error
@@ -42,10 +49,6 @@ type Console interface {
 	Reset() error
 	// Size returns the window size of the console
 	Size() (WinSize, error)
-	// Fd returns the console's file descriptor
-	Fd() uintptr
-	// Name returns the console's file name
-	Name() string
 }
 
 // WinSize specifies the window size of the console
@@ -70,7 +73,7 @@ func Current() Console {
 }
 
 // ConsoleFromFile returns a console using the provided file
-func ConsoleFromFile(f *os.File) (Console, error) {
+func ConsoleFromFile(f File) (Console, error) {
 	if err := checkConsole(f); err != nil {
 		return nil, err
 	}

--- a/console_unix.go
+++ b/console_unix.go
@@ -47,7 +47,7 @@ func NewPty() (Console, string, error) {
 }
 
 type master struct {
-	f        *os.File
+	f        File
 	original *unix.Termios
 }
 
@@ -122,7 +122,7 @@ func (m *master) Name() string {
 }
 
 // checkConsole checks if the provided file is a console
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var termios unix.Termios
 	if tcget(f.Fd(), &termios) != nil {
 		return ErrNotAConsole
@@ -130,7 +130,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	m := &master{
 		f: f,
 	}

--- a/console_windows.go
+++ b/console_windows.go
@@ -198,7 +198,7 @@ func makeInputRaw(fd windows.Handle, mode uint32) error {
 	return nil
 }
 
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var mode uint32
 	if err := windows.GetConsoleMode(windows.Handle(f.Fd()), &mode); err != nil {
 		return err
@@ -206,7 +206,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	if f != os.Stdin && f != os.Stdout && f != os.Stderr {
 		return nil, errors.New("creating a console from a file is not supported on windows")
 	}


### PR DESCRIPTION
The reason of the introduction of the interface is due to the need to pass another thing than a os.File.

In my use case, the problem is that calling `os.Newfile` invalidates the file descriptor after a variable gets out of the scope of a function since `os.File` has a `finalizer`. This forces me to make a global variable to hold it and avoid the GC. Check https://github.com/docker/app/commit/d26c9ad7f5a20a161e9d5d7df7d46c06c69ac565

By accepting an interface (still compatible with `os.File`), another structure can be passed. Like in:
https://github.com/ulyssessouza/buildx/commit/5941345e21ebda43723a475380135fe3741d6b3c
With this approach, a new struct can be passed, like in: https://github.com/docker/app/pull/779/commits/341121245d3217ecb1eeb15b11d52d7d1986adf0#diff-03504424ddde121c663ff197df2ad5caR81-R107
