### PR TITLE
Enable Github Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Console CI
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "::set-env name=GOPATH::${{ github.workspace }}"
+        echo "::add-path::${{ github.workspace }}/bin"
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/console
+        fetch-depth: 25
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        repository: containerd/project
+        path: src/github.com/containerd/project
+
+    - name: Install dependencies
+      env:
+        GO111MODULE: off
+      run: |
+        go get -u github.com/vbatts/git-validation
+        go get -u github.com/kunalkushwaha/ltag
+        go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+        (
+          cd "${GOPATH}/src/github.com/golangci/golangci-lint/cmd/golangci-lint"
+          git checkout v1.23.8
+          go build -v && go install
+        )
+
+    - name: Check DCO/whitespace/commit message
+      env:
+        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+        DCO_VERBOSITY: "-q"
+        DCO_RANGE: ""
+      working-directory: src/github.com/containerd/console
+      run: |
+        if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
+        else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+        fi
+        ../project/script/validate/dco
+
+    - name: Check file headers
+      run: ../project/script/validate/fileheader ../project/
+      working-directory: src/github.com/containerd/console
+
+    - name: Go Linting
+      run: GOGC=75 golangci-lint run
+      working-directory: src/github.com/containerd/console
+
+    - name: Build & Test
+      working-directory: src/github.com/containerd/console
+      run: |
+        go test -race
+        GOOS=openbsd go build
+        GOOS=windows go build
+        GOOS=solaris go build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - golint
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  timeout: 3m
+  skip-dirs:
+    - vendor

--- a/console.go
+++ b/console.go
@@ -73,6 +73,7 @@ func Current() Console {
 }
 
 // ConsoleFromFile returns a console using the provided file
+// nolint:golint
 func ConsoleFromFile(f File) (Console, error) {
 	if err := checkConsole(f); err != nil {
 		return nil, err


### PR DESCRIPTION
Also add linting to CI and remove travis script entries that were no-ops
(there are no tests for other platforms so the extra `go test`
invocations with GOOS settings were not doing anything)

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>