### PR TITLE
Current: allow stdin to be redirected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - "1.12.x"
   - "1.13.x"
+  - "1.14.x"
 
 go_import_path: github.com/containerd/console
 

--- a/console.go
+++ b/console.go
@@ -61,15 +61,20 @@ type WinSize struct {
 	y     uint16
 }
 
-// Current returns the current processes console
-func Current() Console {
-	c, err := ConsoleFromFile(os.Stdin)
-	if err != nil {
-		// stdin should always be a console for the design
-		// of this function
-		panic(err)
+// Current returns the current process' console
+func Current() (c Console) {
+	var err error
+	// Usually all three streams (stdin, stdout, and stderr)
+	// are open to the same console, but some might be redirected,
+	// so try all three.
+	for _, s := range []*os.File{os.Stderr, os.Stdout, os.Stdin} {
+		if c, err = ConsoleFromFile(s); err == nil {
+			return c
+		}
 	}
-	return c
+	// One of the std streams should always be a console
+	// for the design of this function.
+	panic(err)
 }
 
 // ConsoleFromFile returns a console using the provided file


### PR DESCRIPTION
In case we have stdin redirected, we still have a terminal which
can be obtained from stdout or stderr. This is what this commit
does.

This should allow something like this to work:

> ctr run --rm --tty docker.io/library/hello-world:latest xxx < /dev/null

_(found while working on https://github.com/opencontainers/runc/issues/2485)_

NB: in case all three are redirected, but we still have a controlling
tty, we can easily get it by opening /dev/tty, but then it should be
closed, and it's not quite clear by whom and when, so this is left as
a home exersize for the reader.