### PR TITLE
Use Ioctl{SetPointerInt,GetInt} from golang.org/x/sys/unix on linux

### DIFF
--- a/tc_linux.go
+++ b/tc_linux.go
@@ -19,7 +19,6 @@ package console
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -32,17 +31,13 @@ const (
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
 func unlockpt(f *os.File) error {
-	var u int32
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
-		return err
-	}
-	return nil
+	return unix.IoctlSetPointerInt(int(f.Fd()), unix.TIOCSPTLCK, 0)
 }
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	var u uint32
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
+	u, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
+	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("/dev/pts/%d", u), nil


### PR DESCRIPTION
Use `unix.IoctlSetPointerInt` and `unix.IoctlGetInt` instead of manually
implementing them. This avoid the use of the `unsafe` package.