### PR TITLE
GHA: update to Go 1.16.x, actions/setup-go@v2, fix badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.14
+        go-version: 1.16.x
       id: go
 
     - name: Setup Go binary path

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # console
 
-[![Build Status](https://travis-ci.org/containerd/console.svg?branch=master)](https://travis-ci.org/containerd/console)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/console)](https://pkg.go.dev/github.com/containerd/console)
+[![Build Status](https://github.com/containerd/console/workflows/CI/badge.svg)](https://github.com/containerd/console/actions?query=workflow%3ACI)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/console)](https://goreportcard.com/report/github.com/containerd/console)
 
 Golang package for dealing with consoles.  Light on deps and a simple API.
 


### PR DESCRIPTION
- GHA: update to Go 1.16.x, actions/setup-go@v2
- README: update badges to show GHA status
    This was overlooked when switching to GHA. Also adds badges for go.pkg.dev and Go Report Card.