### PR TITLE
add cgo-based FreeBSD support

### DIFF
--- a/console_test.go
+++ b/console_test.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build linux solaris freebsd
 
 /*
    Copyright The containerd Authors.

--- a/console_unix.go
+++ b/console_unix.go
@@ -19,8 +19,6 @@
 package console
 
 import (
-	"os"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -28,7 +26,7 @@ import (
 // The master is returned as the first console and a string
 // with the path to the pty slave is returned as the second
 func NewPty() (Console, string, error) {
-	f, err := os.OpenFile("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+	f, err := openpt()
 	if err != nil {
 		return nil, "", err
 	}

--- a/pty_freebsd_cgo.go
+++ b/pty_freebsd_cgo.go
@@ -1,0 +1,45 @@
+// +build freebsd,cgo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"fmt"
+	"os"
+)
+
+/*
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
+// openpt allocates a new pseudo-terminal and establishes a connection with its
+// control device.
+func openpt() (*os.File, error) {
+	fd, err := C.posix_openpt(C.O_RDWR)
+	if err != nil {
+		return nil, fmt.Errorf("posix_openpt: %w", err)
+	}
+	if _, err := C.grantpt(fd); err != nil {
+		C.close(fd)
+		return nil, fmt.Errorf("grantpt: %w", err)
+	}
+	return os.NewFile(uintptr(fd), ""), nil
+}

--- a/pty_freebsd_nocgo.go
+++ b/pty_freebsd_nocgo.go
@@ -1,0 +1,32 @@
+// +build freebsd,!cgo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
+func openpt() (*os.File, error) {
+	panic("openpt() support requires cgo.")
+}

--- a/pty_unix.go
+++ b/pty_unix.go
@@ -1,0 +1,30 @@
+// +build darwin linux netbsd openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openpt allocates a new pseudo-terminal by opening the /dev/ptmx device
+func openpt() (*os.File, error) {
+	return os.OpenFile("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+}

--- a/tc_freebsd_cgo.go
+++ b/tc_freebsd_cgo.go
@@ -1,0 +1,57 @@
+// +build freebsd,cgo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+/*
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
+const (
+	cmdTcGet = unix.TIOCGETA
+	cmdTcSet = unix.TIOCSETA
+)
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	fd := C.int(f.Fd())
+	if _, err := C.unlockpt(fd); err != nil {
+		C.close(fd)
+		return fmt.Errorf("unlockpt: %w", err)
+	}
+	return nil
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}

--- a/tc_freebsd_nocgo.go
+++ b/tc_freebsd_nocgo.go
@@ -1,3 +1,5 @@
+// +build freebsd,!cgo
+
 /*
    Copyright The containerd Authors.
 
@@ -28,11 +30,19 @@ const (
 	cmdTcSet = unix.TIOCSETA
 )
 
+//
+// Implementing the functions below requires cgo support.  Non-cgo stubs
+// versions are defined below to enable cross-compilation of source code
+// that depends on these functions, but the resultant cross-compiled
+// binaries cannot actually be used.  If the stub function(s) below are
+// actually invoked they will display an error message and cause the
+// calling process to exit.
+//
+
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
-// This does not exist on FreeBSD, it does not allocate controlling terminals on open
 func unlockpt(f *os.File) error {
-	return nil
+	panic("unlockpt() support requires cgo.")
 }
 
 // ptsname retrieves the name of the first available pts for the given master.


### PR DESCRIPTION
FreeBSD does not have a `/dev/ptmx` device unless the [`pty(4)` kernel driver](https://www.freebsd.org/cgi/man.cgi?query=pty&sektion=4) is loaded.  When that module is not loaded, pty devices can be allocated with [`posix_openpt(2)`](https://www.freebsd.org/cgi/man.cgi?query=posix_openpt&sektion=2&apropos=0&manpath=FreeBSD+12.2-RELEASE+and+Ports) instead.