### PR TITLE
Fix ptsname() for big-endian architectures (again)

### DIFF
--- a/tc_linux.go
+++ b/tc_linux.go
@@ -33,6 +33,7 @@ const (
 // unlockpt should be called before opening the slave side of a pty.
 func unlockpt(f *os.File) error {
 	var u int32
+	// XXX do not use unix.IoctlSetPointerInt here, see commit dbd69c59b81.
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return err
 	}
@@ -42,6 +43,7 @@ func unlockpt(f *os.File) error {
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
 	var u uint32
+	// XXX do not use unix.IoctlGetInt here, see commit dbd69c59b81.
 	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}

--- a/tc_linux.go
+++ b/tc_linux.go
@@ -19,6 +19,7 @@ package console
 import (
 	"fmt"
 	"os"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -31,13 +32,17 @@ const (
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
 func unlockpt(f *os.File) error {
-	return unix.IoctlSetPointerInt(int(f.Fd()), unix.TIOCSPTLCK, 0)
+	var u int32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
+		return err
+	}
+	return nil
 }
 
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	u, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
-	if err != nil {
+	var u uint32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}
 	return fmt.Sprintf("/dev/pts/%d", u), nil


### PR DESCRIPTION
This reverts commit f1b333f2c5050f (Use Ioctl{SetPointerInt,GetInt} from
golang.org/x/sys/unix on linux), changing the code to what it was after
commit dbd69c59b81. This fixes a blocker bug on s390 [1].

The original description from commit dbd69c59b81 follows:

    On big-endian architectures unix.IoctlGetInt() leads to a wrong result
    because a 32 bit value is stored into a 64 bit buffer. When dereferencing
    the result is left shifted by 32. Without this patch ptsname() returns
    a wrong path from the second pty onwards.
    To protect syscalls against re-arranging by the GC the conversion from
    unsafe.Pointer to uintptr must occur in the Syscall expression itself.
    See the documentation of the unsafe package for details.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1941815

This is a regression in v1.0.1, so ideally we need a new 1.0.2 release after merging this.