### PR TITLE
Add missing import in freebsd nocgo stub

### DIFF
--- a/pty_freebsd_nocgo.go
+++ b/pty_freebsd_nocgo.go
@@ -18,6 +18,10 @@
 
 package console
 
+import (
+	"os"
+)
+
 //
 // Implementing the functions below requires cgo support.  Non-cgo stubs
 // versions are defined below to enable cross-compilation of source code


### PR DESCRIPTION
```
$ GOOS=freebsd CGO_ENABLED=0 go build .
# github.com/containerd/console
./pty_freebsd_nocgo.go:30:17: undefined: os
```