### PR TITLE
fix: add shim for js

### DIFF
--- a/console.go
+++ b/console.go
@@ -22,7 +22,10 @@ import (
 	"os"
 )
 
-var ErrNotAConsole = errors.New("provided file is not a console")
+var (
+	ErrNotAConsole    = errors.New("provided file is not a console")
+	ErrNotImplemented = errors.New("not implemented")
+)
 
 type File interface {
 	io.ReadWriteCloser

--- a/console_other.go
+++ b/console_other.go
@@ -1,0 +1,36 @@
+//go:build !darwin && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows && !zos
+// +build !darwin,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows,!zos
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+// NewPty creates a new pty pair
+// The master is returned as the first console and a string
+// with the path to the pty slave is returned as the second
+func NewPty() (Console, string, error) {
+	return nil, "", ErrNotImplemented
+}
+
+// checkConsole checks if the provided file is a console
+func checkConsole(f File) error {
+	return ErrNotAConsole
+}
+
+func newMaster(f File) (Console, error) {
+	return nil, ErrNotImplemented
+}

--- a/console_windows.go
+++ b/console_windows.go
@@ -24,10 +24,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var (
-	vtInputSupported  bool
-	ErrNotImplemented = errors.New("not implemented")
-)
+var vtInputSupported bool
 
 func (m *master) initStdios() {
 	// Note: We discard console mode warnings, because in/out can be redirected.


### PR DESCRIPTION
Fixes build with:

env GOOS=js GOARCH=wasm go build -trimpath .
