### PR TITLE
fix: don't print to stdout when initializing console fails on Windows

### DIFF
--- a/console_windows.go
+++ b/console_windows.go
@@ -30,6 +30,10 @@ var (
 )
 
 func (m *master) initStdios() {
+	// Note: We discard console mode warnings, because in/out can be redirected.
+	//
+	// TODO: Investigate opening CONOUT$/CONIN$ to handle this correctly
+
 	m.in = windows.Handle(os.Stdin.Fd())
 	if err := windows.GetConsoleMode(m.in, &m.inMode); err == nil {
 		// Validate that windows.ENABLE_VIRTUAL_TERMINAL_INPUT is supported, but do not set it.
@@ -39,8 +43,6 @@ func (m *master) initStdios() {
 		// Unconditionally set the console mode back even on failure because SetConsoleMode
 		// remembers invalid bits on input handles.
 		windows.SetConsoleMode(m.in, m.inMode)
-	} else {
-		fmt.Printf("failed to get console mode for stdin: %v\n", err)
 	}
 
 	m.out = windows.Handle(os.Stdout.Fd())
@@ -50,8 +52,6 @@ func (m *master) initStdios() {
 		} else {
 			windows.SetConsoleMode(m.out, m.outMode)
 		}
-	} else {
-		fmt.Printf("failed to get console mode for stdout: %v\n", err)
 	}
 
 	m.err = windows.Handle(os.Stderr.Fd())
@@ -61,8 +61,6 @@ func (m *master) initStdios() {
 		} else {
 			windows.SetConsoleMode(m.err, m.errMode)
 		}
-	} else {
-		fmt.Printf("failed to get console mode for stderr: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
When stdin/err/out are redirected, console mode can't be changed. That's often expected & acceptable however, so we shouldn't print errors to stdout.