### PR TITLE
Update GitHub actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
 
   build:
     name: Console CI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.19.x
       id: go
 
     - name: Setup Go binary path
@@ -27,13 +27,13 @@ jobs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/console
         fetch-depth: 25
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: containerd/project
         path: src/github.com/containerd/project
@@ -42,7 +42,7 @@ jobs:
       run: |
         go install github.com/vbatts/git-validation@latest
         go install github.com/kunalkushwaha/ltag@latest
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.0
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
     - name: Check DCO/whitespace/commit message
       env:


### PR DESCRIPTION
Updates actions runner OS from Ubuntu 18.04 to Ubuntu 22.04. Updates actions/checkout and actions/setup-go packages from v2 to v3. Updates golangci/golangci-lint from v1.44.0 to v1.50.1.

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>