### PR TITLE
[Doc]update links to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ current.Resize(ws)
 
 console is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
 As a containerd sub-project, you will find the:
- * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
- * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
- * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+ * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/main/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.


### PR DESCRIPTION
Since default branch of repo [github.com/containerd/project](https://github.com/containerd/project) changed to main, update the document links accordingly.

Signed-off-by: Tony Fang [nhfang@amazon.com](mailto:nhfang@amazon.com)