### PR TITLE
tc_unix.go: Make cfmakeraw compatible to Linux

### DIFF
--- a/tc_unix.go
+++ b/tc_unix.go
@@ -84,7 +84,7 @@ func cfmakeraw(t unix.Termios) unix.Termios {
 	t.Oflag &^= unix.OPOST
 	t.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	t.Cflag &^= (unix.CSIZE | unix.PARENB)
-	t.Cflag &^= unix.CS8
+	t.Cflag |= unix.CS8
 	t.Cc[unix.VMIN] = 1
 	t.Cc[unix.VTIME] = 0
 


### PR DESCRIPTION
According to `termios(3)`, `cfmakeraw` should perform `or` on `c_cflag` with `CS8`.
But the current our `cfmakeraw` implementation doesn't do that but clears that bit.
This commit fixes `cfmakeraw` to make it behave same as Linux's one.

https://man7.org/linux/man-pages/man3/termios.3.html

```
           termios_p->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
                           | INLCR | IGNCR | ICRNL | IXON);
           termios_p->c_oflag &= ~OPOST;
           termios_p->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
           termios_p->c_cflag &= ~(CSIZE | PARENB);
           termios_p->c_cflag |= CS8;
```