### PR TITLE
Stop panicking in `Current()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Golang package for dealing with consoles.  Light on deps and a simple API.
 ## Modifying the current process
 
 ```go
-current := console.Current()
+current, err := console.Current()
+if err != nil {
+}
 defer current.Reset()
 
 if err := current.SetRaw(); err != nil {

--- a/console.go
+++ b/console.go
@@ -65,19 +65,17 @@ type WinSize struct {
 }
 
 // Current returns the current process' console
-func Current() (c Console) {
-	var err error
+func Current() (c Console, err error) {
 	// Usually all three streams (stdin, stdout, and stderr)
 	// are open to the same console, but some might be redirected,
 	// so try all three.
 	for _, s := range []*os.File{os.Stderr, os.Stdout, os.Stdin} {
 		if c, err = ConsoleFromFile(s); err == nil {
-			return c
+			return c, nil
 		}
 	}
-	// One of the std streams should always be a console
-	// for the design of this function.
-	panic(err)
+
+	return nil, err
 }
 
 // ConsoleFromFile returns a console using the provided file


### PR DESCRIPTION
Instead, just return an error, so it's up to the calling code how to handle it.

This is an API-breaking change.