### PR TITLE
return early for closed console during shutdown

### DIFF
--- a/console_linux.go
+++ b/console_linux.go
@@ -260,6 +260,10 @@ func (ec *EpollConsole) Shutdown(close func(int) error) error {
 	ec.writec.L.Lock()
 	defer ec.writec.L.Unlock()
 
+	if ec.closed {
+		return nil
+	}
+
 	ec.readc.Broadcast()
 	ec.writec.Broadcast()
 	ec.closed = true


### PR DESCRIPTION
I believe this patch is required for a proper implementation of https://github.com/containerd/containerd/pull/11161.

Without this patch, double invocation of `Shutdown` will cause the shim to hang for the `TestContainerExecLargeOutputWithTTY` test case.